### PR TITLE
Exports Playlist with RabbitMQ

### DIFF
--- a/.env.dev
+++ b/.env.dev
@@ -16,3 +16,6 @@ ACCESS_TOKEN_KEY=
 REFRESH_TOKEN_KEY=
 # age in seconds
 ACCESS_TOKEN_AGE=1800
+
+# Message Broker
+RABBITMQ_SERVER=amqp://localhost

--- a/.env.prod
+++ b/.env.prod
@@ -16,3 +16,6 @@ ACCESS_TOKEN_KEY=
 REFRESH_TOKEN_KEY=
 # age in seconds
 ACCESS_TOKEN_AGE=15
+
+# Message Broker
+RABBITMQ_SERVER=amqp://0.0.0.0

--- a/docs/scenario.v3.md
+++ b/docs/scenario.v3.md
@@ -1,0 +1,77 @@
+- [Skenario 1: Terdapat fitur ekspor lagu pada playlist](#skenario-1-terdapat-fitur-ekspor-lagu-pada-playlist)
+- [Skenario 2: Terdapat fitur mengunggah gambar](#skenario-2-terdapat-fitur-mengunggah-gambar)
+- [Skenario 3: Applying Server-Side Cache](#skenario-3-applying-server-side-cache)
+- [Skenario 4: Keep the feature from OpenMusic API v2 and v1 up.](#skenario-4-keep-the-feature-from-openmusic-api-v2-and-v1-up)
+
+## Skenario 1: Terdapat fitur ekspor lagu pada playlist
+- request header:
+  - method: **POST**
+  - url: **/exports/playlists/{playlistId}**
+- request body:
+  ```json
+  {
+    "targetEmail": string,
+  }
+  ```
+- provision:
+  - **targetEmail** must be a valid valid email, not just any string value
+  - the users who can export the playlist must be the owner or the collaborator of the playlist.
+  - must use the message broker using `RabbitMQ`
+    - the name of the `RabbitMQ` host must use the environment variable value named `RABBITMQ_SERVER`
+  - must create queue consumer app
+  - the exported result is a json data
+  - The exported result must be sent using `nodemailer`
+    - The email credentials must be using `MAIL_ADDRESS` and `MAIL_PASSWORD` environment variables
+- response header:
+  - status code: **201** (Created)
+  - **Content-Type**: **application/json; charset=utf-8**
+- response body:
+  ```json
+  {
+    "status": "success",
+    "message": "Permintaan Anda sedang kami proses",
+  }
+  ```
+
+## Skenario 2: Terdapat fitur mengunggah gambar
+- request header:
+  - method: **POST**
+  - url: **/upload/pictures**
+- request body:
+  ```json
+  {
+    "data": file
+  }
+  ```
+- provision:
+  - the type of content must be [MIME Types of images](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types#image_types)
+  - the maximum file allowed is 500KB
+  - you must use either local system storage or AWS S3 bucket to accomodate the object
+  - if using Amazon S3 must using AWS_BUCKET_NAME environment variable.
+- response header:
+  - status code: **201** (Created)
+  - **Content-Type**: **application/json; charset=utf-8**
+- response body:
+  ```json
+  {
+    "status": "success",
+    "message": "Gambar berhasil diunggah",
+    "data": {
+        "pictureUrl": "http://…"
+    }
+
+  }
+  ```
+
+## Skenario 3: Applying Server-Side Cache
+- request header:
+  - method: **GET**
+  - url: **/playlists/{playlistId}/songs**
+- provision:
+  - cache must be deleted if there is a song deleted or a new song  added to the playlist
+  - the memory engine must use `Redis` or `Memurai` (Windows)
+  - the `Redis` hostname must be used `REDIS_SERVER` environment variable
+
+## Skenario 4: Keep the feature from OpenMusic API v2 and v1 up.
+- provision:
+  - make sure the feature and the criteria from OpenMusic API v2 and v1 is still working.

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "dependencies": {
     "@hapi/hapi": "^20.2.1",
     "@hapi/jwt": "^2.1.0",
+    "amqplib": "^0.8.0",
     "bcrypt": "^5.0.1",
     "dotenv": "^10.0.0",
     "joi": "^17.4.3",

--- a/src/api/exports/handler.js
+++ b/src/api/exports/handler.js
@@ -1,0 +1,54 @@
+/**
+ * A class to handle export songs in a playlist
+ */
+class ExportsHandler {
+  /**
+   * @param {class} producerService used to access database mode
+   * @param {class} playlistsService used to verify that only the owner or
+   * collaborator who can export the songs from a playlist
+   * @param {class} validator used to validate user inputs
+   */
+  constructor(producerService, playlistsService, validator) {
+    this._producerService = producerService;
+    this._playlistsService = playlistsService;
+    this._validator = validator;
+
+    this.postExportPlaylistHandler = this.postExportPlaylistHandler.bind(this);
+  }
+
+  /**
+   * A function to create a playlist
+   * @param {object} request request parameter from hapi requests
+   * @param {object} h to make the responses
+   * @return {response/error}
+   */
+  async postExportPlaylistHandler(request, h) {
+    this._validator.validateExportPlaylistPayload(request.payload);
+
+    const {id: credentialId} = request.auth.credentials;
+    const {playlistId} = request.params;
+
+    await this
+        ._playlistsService
+        .verifyPlaylistAccess(playlistId, credentialId);
+    const message = {
+      userId: credentialId,
+      playlistId: playlistId,
+      targetEmail: request.payload.targetEmail,
+    };
+
+    await this._producerService.sendMessage(
+        'export:songs',
+        JSON.stringify(message),
+    );
+
+    const response = h.response({
+      status: 'success',
+      message: 'Permintaan Anda sedang kami proses',
+    });
+    response.code(201);
+    return response;
+  }
+}
+
+module.exports = ExportsHandler;

--- a/src/api/exports/index.js
+++ b/src/api/exports/index.js
@@ -1,0 +1,13 @@
+const ExportsHandler = require('./handler');
+const routes = require('./routes');
+
+module.exports = {
+  name: 'exports',
+  version: '1.0.0',
+  register: async (server, {producerService, playlistsService, validator}) => {
+    const exportsHandler = new ExportsHandler(
+        producerService, playlistsService, validator,
+    );
+    server.route(routes(exportsHandler));
+  },
+};

--- a/src/api/exports/routes.js
+++ b/src/api/exports/routes.js
@@ -1,0 +1,12 @@
+const routes = (handler) => [
+  {
+    method: 'POST',
+    path: '/exports/playlists/{playlistId}',
+    handler: handler.postExportPlaylistHandler,
+    options: {
+      auth: 'openmusic_jwt',
+    },
+  },
+];
+
+module.exports = routes;

--- a/src/server.js
+++ b/src/server.js
@@ -32,6 +32,10 @@ const CollaborationsService = require(
     './services/postgres/CollaborationsService',
 );
 const CollaborationsValidator = require('./validator/collaborations');
+// exports
+const _exports = require('./api/exports');
+const ProducerService = require('./services/rabbitmq/ProducerService');
+const ExportsValidator = require('./validator/exports');
 
 const init = async () => {
   const collaborationsService = new CollaborationsService();
@@ -112,6 +116,14 @@ const init = async () => {
         collaborationsService,
         playlistsService,
         validator: CollaborationsValidator,
+      },
+    },
+    {
+      plugin: _exports,
+      options: {
+        producerService: ProducerService,
+        playlistsService,
+        validator: ExportsValidator,
       },
     },
   ]);

--- a/src/services/rabbitmq/ProducerService.js
+++ b/src/services/rabbitmq/ProducerService.js
@@ -1,0 +1,19 @@
+const amqplib = require('amqplib');
+
+const ProducerService = {
+  sendMessage: async (queue, message) => {
+    const connection = await amqplib.connect(process.env.RABBITMQ_SERVER);
+    const channel = await connection.createChannel();
+    await channel.assertQueue(queue, {
+      durable: true,
+    });
+
+    await channel.sendToQueue(queue, Buffer.from(message));
+
+    setTimeout(() => {
+      connection.close();
+    }, 1000);
+  },
+};
+
+module.exports = ProducerService;

--- a/src/validator/exports/index.js
+++ b/src/validator/exports/index.js
@@ -1,0 +1,14 @@
+const ExportPlaylistPayloadSchema = require('./schema');
+const InvariantError = require('../../errors/InvariantError');
+
+const ExportsValidator = {
+  validateExportPlaylistPayload: (payload) => {
+    const validationResult = ExportPlaylistPayloadSchema.validate(payload);
+
+    if (validationResult.error) {
+      throw new InvariantError(validationResult.error.message);
+    }
+  },
+};
+
+module.exports = ExportsValidator;

--- a/src/validator/exports/schema.js
+++ b/src/validator/exports/schema.js
@@ -1,0 +1,7 @@
+const Joi = require('joi');
+
+const ExportPlaylistPayloadSchema = Joi.object({
+  targetEmail: Joi.string().email({tlds: true}).required(),
+});
+
+module.exports = ExportPlaylistPayloadSchema;


### PR DESCRIPTION
this feature uses [exports queue consumer](https://github.com/ryumada/hapi-openmusic-quequeConsumer-exports) that will listen to [Producer Service](https://github.com/ryumada/hapi-openmusic/commit/627f984b71cf6689370fb0b9c800b8120044652c) created.